### PR TITLE
SR-2834 Bump `Django` to `4.2.16`

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @uktrade/webops

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# SAML Test Client
+
+A simple Django app, which acts as a SAML test client. 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==4.2.8
+Django==4.2.16
 djangosaml2==1.9.1
 dj-database-url
 django-environ


### PR DESCRIPTION
This will clear up the 10 security alerts present in the repository.

There are no tests, however, I have run the application locally to ensure that the upgrade doesn't cause any issues.